### PR TITLE
Use `#` instead of `$ sudo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Dell G5SE-5505 laptop isn't working with usual fan managers, this script is 
 This is a python script, you'll need python, and the `sys`, `os`, `time` python libraries.
 You will also need to modprobe the dell smm kernel module, which is not loaded by default on this laptop.
 ```shell
-$ sudo modprobe dell-smm-hwmon restricted=0 ignore_dmi=1
+# modprobe dell-smm-hwmon restricted=0 ignore_dmi=1
 ```
 If you want this setting to stay upon reboot, you can create a / replace by or append to the config file  `/etc/modules-load.d/dell-smm-hwmon.conf` 
 ```shell
@@ -17,11 +17,11 @@ options dell-smm-hwmon restricted=0 ignore_dmi=1
 ```
 ## Usage
 ```shell
-$ sudo python DellG5SEFan.py lowtemp maxtemp timer
+# python DellG5SEFan.py lowtemp maxtemp timer
 ```
 For instance, 
 ```shell
-$ sudo python DellG5SEFan.py 50 65 10
+# python DellG5SEFan.py 50 65 10
 ```
 will disable fans for temperature below 50°C, put fans at 50% between 50°C and 65°C and at 100% over 65°C, with a 10 second loop.
 


### PR DESCRIPTION
A root shell command is shown using a `#`. There is no need for `$ sudo`